### PR TITLE
Add missing backtick to Complement of an intersection

### DIFF
--- a/Game/Levels/Combo/L02compint.lean
+++ b/Game/Levels/Combo/L02compint.lean
@@ -17,7 +17,7 @@ The trick to get started on this proof is to rewrite `Aᶜ ∪ Bᶜ` as `(Aᶜ �
 know, `comp_comp (Aᶜ ∪ Bᶜ)` is a proof of the theorem `(Aᶜ ∪ Bᶜ)ᶜᶜ = Aᶜ ∪ Bᶜ`, and therefore
 `rewrite [comp_comp (Aᶜ ∪ Bᶜ)]` could be used to rewrite `(Aᶜ ∪ Bᶜ)ᶜᶜ` as `Aᶜ ∪ Bᶜ`; but we
 want to go in the opposite direction, rewriting `Aᶜ ∪ Bᶜ` as `(Aᶜ ∪ Bᶜ)ᶜᶜ`. To do that, use
-rewrite [← comp_comp (Aᶜ ∪ Bᶜ)]`. (To enter the left-pointing arrow, type `\\l`.)
+`rewrite [← comp_comp (Aᶜ ∪ Bᶜ)]`. (To enter the left-pointing arrow, type `\\l`.)
 "
 
 LemmaTab "ᶜ"


### PR DESCRIPTION
The current version of the game has a formatting error:
![image](https://github.com/djvelleman/STG4/assets/12386291/96c74e9a-027f-4c95-b73e-e07490879798)
